### PR TITLE
frameworks: base: Port password retention feature

### DIFF
--- a/core/java/com/android/internal/widget/ILockSettings.aidl
+++ b/core/java/com/android/internal/widget/ILockSettings.aidl
@@ -93,4 +93,6 @@ interface ILockSettings {
     boolean hasSecureLockScreen();
     boolean tryUnlockWithCachedUnifiedChallenge(int userId);
     void removeCachedUnifiedChallenge(int userId);
+    void sanitizePassword();
+    String getPassword();
 }

--- a/core/java/com/android/internal/widget/LockPatternUtils.java
+++ b/core/java/com/android/internal/widget/LockPatternUtils.java
@@ -672,6 +672,17 @@ public class LockPatternUtils {
         reportEnabledTrustAgentsChanged(userHandle);
     }
 
+    /**
+     * clears stored password.
+     */
+    public void sanitizePassword() {
+        try {
+            getLockSettings().sanitizePassword();
+        } catch (RemoteException re) {
+            Log.e(TAG, "Couldn't sanitize password" + re);
+        }
+    }
+
     private void updateCryptoUserInfo(int userId) {
         if (userId != UserHandle.USER_SYSTEM) {
             return;

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputView.java
@@ -205,6 +205,7 @@ public abstract class KeyguardAbsKeyInputView extends LinearLayout
             boolean isValidPassword) {
         boolean dismissKeyguard = KeyguardUpdateMonitor.getCurrentUser() == userId;
         if (matched) {
+            mLockPatternUtils.sanitizePassword();
             mCallback.reportUnlockAttempt(userId, true, 0);
             if (dismissKeyguard) {
                 mDismissing = true;

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPatternView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPatternView.java
@@ -349,6 +349,7 @@ public class KeyguardPatternView extends LinearLayout implements KeyguardSecurit
                 boolean isValidPattern) {
             boolean dismissKeyguard = KeyguardUpdateMonitor.getCurrentUser() == userId;
             if (matched) {
+                mLockPatternUtils.sanitizePassword();
                 mCallback.reportUnlockAttempt(userId, true, 0);
                 if (dismissKeyguard) {
                     mLockPatternView.setDisplayMode(LockPatternView.DisplayMode.Correct);

--- a/services/core/java/com/android/server/StorageManagerService.java
+++ b/services/core/java/com/android/server/StorageManagerService.java
@@ -154,6 +154,7 @@ import com.android.internal.util.FastXmlSerializer;
 import com.android.internal.util.HexDump;
 import com.android.internal.util.IndentingPrintWriter;
 import com.android.internal.util.Preconditions;
+import com.android.internal.widget.ILockSettings;
 import com.android.internal.widget.LockPatternUtils;
 import com.android.server.pm.Installer;
 import com.android.server.storage.AppFuseBridge;
@@ -2997,8 +2998,22 @@ class StorageManagerService extends IStorageManager.Stub
             Slog.i(TAG, "changing encryption password...");
         }
 
+        ILockSettings lockSettings = ILockSettings.Stub.asInterface(
+                        ServiceManager.getService("lock_settings"));
+        String currentPassword="default_password";
         try {
-            mVold.fdeChangePassword(type, password);
+            currentPassword = lockSettings.getPassword();
+        } catch (Exception e) {
+            Slog.wtf(TAG, "Couldn't get password" + e);
+        }
+
+        try {
+            mVold.fdeChangePassword(type, currentPassword, password);
+            try {
+                lockSettings.sanitizePassword();
+            } catch (Exception e) {
+                Slog.wtf(TAG, "Couldn't sanitize password" + e);
+            }
             return 0;
         } catch (Exception e) {
             Slog.wtf(TAG, e);


### PR DESCRIPTION
Port password retention feature for HW FDE.

This patch also include these changes:
   - Fix clearing of retained password
   - keyguard: Fix password doesnot sanitize after verification
   - LockSettings: fix the get password issue during boot up
   - frameworks/base: Fix pattern update issue

 Conflicts:
	core/java/com/android/internal/widget/ILockSettings.aidl
	core/java/com/android/internal/widget/LockPatternUtils.java
	services/core/java/com/android/server/locksettings/LockSettingsService.java

CRs-Fixed: 2210986
Change-Id: I2def56b14c10229b72feccd1c97b281cad65f282
Signed-off-by: Volodymyr Zhdanov <wight554@gmail.com>