### PR TITLE
Fix Build Credentials refactored to use byte[]

### DIFF
--- a/services/core/java/com/android/server/locksettings/LockSettingsService.java
+++ b/services/core/java/com/android/server/locksettings/LockSettingsService.java
@@ -2014,7 +2014,9 @@ public class LockSettingsService extends ILockSettings.Stub {
                                             0, userId, progressCallback);
             if ((response.getResponseCode() == VerifyCredentialResponse.RESPONSE_OK) &&
                                             (userId == UserHandle.USER_OWNER)) {
-                    retainPassword(credential);
+                    //TODO(b/127810705): Update to credentials to use byte[]
+                    String credentialString = credential.isNone() ? null : new String(credential.getCredential());
+                    retainPassword(credentialString);
             }
             return response;
         } finally {


### PR DESCRIPTION
 Conflicts:
	services/core/java/com/android/server/locksettings/LockSettingsService.java

[wight554: updated code from LA.QSSI.11.0.r1-05600-qssi.0]

Bug: 127810705
Change-Id: I766b553aef0479c286c0eee7302bb5e3b04b85bf
Signed-off-by: Volodymyr Zhdanov <wight554@gmail.com>